### PR TITLE
version bump, bumping yaxpeax-arch to 0.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "yaxpeax-avr"
 description = "AVR instruction set decoder for yaxpeax"
 authors = [ "The6P4C <watsonjcampbell@gmail.com>" ]
-version = "0.0.1"
+version = "0.0.2"
 license = "0BSD"
 edition = "2018"
 repository = "https://github.com/The6P4C/yaxpeax-avr"
 
 [dependencies]
-yaxpeax-arch = { version = "0.0.3", default-features = false, features = [] }
+yaxpeax-arch = { version = "0.0.4", default-features = false, features = [] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!   invalid.
 extern crate yaxpeax_arch;
 
-use yaxpeax_arch::{Arch, Decoder, LengthedInstruction};
+use yaxpeax_arch::{Arch, AddressDiff, Decoder, LengthedInstruction};
 
 use std::fmt;
 
@@ -414,14 +414,14 @@ impl yaxpeax_arch::Instruction for Instruction {
 }
 
 impl LengthedInstruction for Instruction {
-    type Unit = <AVR as Arch>::Address;
+    type Unit = AddressDiff<<AVR as Arch>::Address>;
 
     fn min_size() -> Self::Unit {
-        2
+        AddressDiff::from_const(2)
     }
 
     fn len(&self) -> Self::Unit {
-        self.length as Self::Unit
+        AddressDiff::from_const(self.length as <AVR as Arch>::Address)
     }
 }
 


### PR DESCRIPTION
hi! yaxpeax-arch 0.0.4 changes `LengthedInstruction` to use the new `AddressDiff` type. this PR alone gets `yaxpeax-avr` on `yaxpeax-arch 0.0.4` and updates for that breakage, at which point i'll glue it into `yaxdis` and update all that.

i remember we also talked about some cases where it might make sense to not have a single flat memory space when considering AVR programs, and this ought to help a wee bit to that end too.