### PR TITLE
version bump, bumping yaxpeax-arch to 0.0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "yaxpeax-avr"
 description = "AVR instruction set decoder for yaxpeax"
 authors = [ "The6P4C <watsonjcampbell@gmail.com>" ]
-version = "0.0.2"
+version = "0.0.3"
 license = "0BSD"
 edition = "2018"
 repository = "https://github.com/The6P4C/yaxpeax-avr"
 
 [dependencies]
-yaxpeax-arch = { version = "0.0.4", default-features = false, features = [] }
+yaxpeax-arch = { version = "0.0.5", default-features = false, features = [] }


### PR DESCRIPTION
hi again! yaxpeax-arch 0.0.5 swaps the `termion` dependency for `crossterm`, for better cross-platform terminal usage. this doesn't really impact yaxpeax-avr much, but because -arch is an `0.0.x` dependency, cargo can't automatically pick `0.0.5` instead, and trying to use -arch `0.0.4` and `0.0.5` at the same time ends up confusing rustc over `yaxpeax_arch::Arch` impls.

there are a few rough spots in yapxeax-arch to sand out (as you know, because you found them :crying_cat_face:) but hopefully i can commit to a `yaxpeax-arch 0.1.0` soon and things like this will matter ... less.